### PR TITLE
Add survival multi-task support

### DIFF
--- a/scripts/train_survival.sh
+++ b/scripts/train_survival.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This script is for continued pre-training of TabICL on synthetic survival data.
+
+# Set the path to your last training checkpoint
+# IMPORTANT: Replace this with the actual path to your checkpoint file.
+# This should be the model state before the final classification head was attached,
+# often saved as step_{latest}.ckpt from a previous training run.
+LAST_CHECKPOINT_PATH="/path/to/your/stage2/checkpoint/dir/step-{latest}.ckpt"
+
+# Set the directory for the new survival model checkpoints
+SURVIVAL_CHECKPOINT_DIR="/my/survival/checkpoint/dir"
+
+torchrun --standalone --nproc_per_node=1 /path/to/cRisQ-t1/src/tabicl/train/run.py \
+    --wandb_log True \
+    --wandb_project cRisQ-t1 \
+    --wandb_name Survival-Pretraining \
+    --wandb_mode online \
+    --device cuda \
+    --dtype bfloat16 \
+    --max_steps 50000 \
+    --batch_size 256 \
+    --micro_batch_size 2 \
+    --lr 5e-5 \
+    --scheduler cosine_warmup \
+    --warmup_proportion 0.05 \
+    --gradient_clipping 1.0 \
+    --prior_type mix_scm \
+    --prior_device cpu \
+    --batch_size_per_gp 4 \
+    --min_features 10 \
+    --max_features 100 \
+    --max_classes 2 \
+    --min_seq_len 1000 \
+    --max_seq_len 40000 \
+    --log_seq_len True \
+    --min_train_size 0.5 \
+    --max_train_size 0.9 \
+    --embed_dim 128 \
+    --col_num_blocks 3 \
+    --col_nhead 4 \
+    --col_num_inds 128 \
+    --row_num_blocks 3 \
+    --row_nhead 8 \
+    --row_num_cls 4 \
+    --row_rope_base 100000 \
+    --icl_num_blocks 12 \
+    --icl_nhead 4 \
+    --ff_factor 2 \
+    --norm_first True \
+    --checkpoint_dir $SURVIVAL_CHECKPOINT_DIR \
+    --checkpoint_path $LAST_CHECKPOINT_PATH \
+    --save_perm_every 1000 \
+    --only_load_model True # IMPORTANT: This ensures you only load the model weights, not the optimizer state, which is crucial for changing the task.
+
+echo "Survival pre-training script finished."

--- a/src/tabicl/model/learning.py
+++ b/src/tabicl/model/learning.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import math
 import torch
 from torch import nn, Tensor
 
-from .layers import ClassNode, OneHotAndLinear
+from .layers import OneHotAndLinear
 from .encoders import Encoder
 
 
@@ -73,121 +72,23 @@ class ICLearning(nn.Module):
         if self.norm_first:
             self.ln = nn.LayerNorm(d_model)
 
-        self.y_encoder = OneHotAndLinear(max_classes, d_model)
-        self.decoder = nn.Sequential(nn.Linear(d_model, d_model * 2), nn.GELU(), nn.Linear(d_model * 2, max_classes))
+        # --- New multi-head setup for survival analysis ---
+        # Encoder for the binary event label
+        self.event_encoder = OneHotAndLinear(2, d_model)  # Event is binary (0 or 1)
 
-    def _grouping(self, num_classes: int) -> tuple[Tensor, int]:
-        """Divide classes into balanced groups for hierarchical classification.
+        # A simple linear layer to project the continuous time value into the model dimension
+        self.time_encoder = nn.Linear(1, d_model)
 
-        This method implements a balanced partitioning strategy that divides classes
-        into approximately equal-sized groups to minimize tree depth. The number of
-        groups formed at this level will not exceed `max_classes`.
+        # Classification head for predicting the event
+        self.classification_head = nn.Sequential(nn.Linear(d_model, d_model), nn.GELU(), nn.Linear(d_model, 1))
 
-        Parameters
-        ----------
-        num_classes : int
-            Total number of unique classes to partition into groups
+        # Regression head for predicting the time-to-event
+        self.regression_head = nn.Sequential(nn.Linear(d_model, d_model), nn.GELU(), nn.Linear(d_model, 1))
 
-        Returns
-        -------
-        tuple[Tensor, int]
-            - group_assignments: Tensor mapping each class index to its assigned group (0-indexed)
-            - num_groups: Total number of groups created (will be <= max_classes)
+        # Keep the original decoder for compatibility if needed, but we won't use it for survival task
+        self.original_decoder = nn.Sequential(nn.Linear(d_model, d_model * 2), nn.GELU(), nn.Linear(d_model * 2, max_classes))
+        # --- End of new setup ---
 
-        Notes
-        -----
-        For example, with max_classes=10 and num_classes=25:
-        - Distributes 25 classes into 3 groups. Sizes: [9, 8, 8].
-        - Returns assignments tensor and num_groups = 3.
-
-        With max_classes=10 and num_classes=101:
-        - Distributes 101 classes into 10 groups. Sizes: [11, 10, 10, 10, 10, 10, 10, 10, 10, 10].
-        - Returns assignments tensor and num_groups = 10.
-        - The child node receiving 11 classes will be further divided into 2 groups: [6, 5].
-        """
-
-        if num_classes <= self.max_classes:
-            return torch.zeros(num_classes, dtype=torch.int), 1
-
-        num_groups = min(math.ceil(num_classes / self.max_classes), self.max_classes)
-        group_assignments = torch.zeros(num_classes, dtype=torch.int)
-        current_pos = 0
-
-        remaining_classes = num_classes
-        remaining_groups = num_groups
-        for i in range(num_groups):
-            group_size = math.ceil(remaining_classes / remaining_groups)
-            group_assignments[current_pos : current_pos + group_size] = i
-            current_pos += group_size
-            remaining_classes -= group_size
-            remaining_groups -= 1
-
-        return group_assignments, num_groups
-
-    def _fit_node(self, node: ClassNode, R: Tensor, y: Tensor, current_depth: int):
-        """Recursively build a node in the hierarchical classification tree.
-
-        For each node, this method either:
-        1. Creates a leaf node if the number of classes is small enough to handle directly
-        2. Splits classes into groups and recursively creates child nodes for each group
-
-        Parameters
-        ----------
-        node : ClassNode
-            Current node being constructed in the tree
-
-        R : Tensor
-            Row representations of shape (num_samples, D) where num_samples is the number of
-            examples assigned to this node
-
-        y : Tensor
-            Targets of shape (num_samples,) corresponding to the samples in R
-
-        current_depth : int
-            Current depth in the hierarchical tree (root = 0)
-        """
-
-        unique_classes = torch.unique(y).int()
-        node.classes_ = unique_classes
-
-        if len(unique_classes) <= self.max_classes:
-            # Create leaf node for direct classification
-            node.is_leaf = True
-            node.R = R
-            node.y = y
-            return
-
-        # Merge classes into groups
-        group_assignments, num_groups = self._grouping(len(unique_classes))
-
-        # Create mapping from original class labels to their corresponding group numbers
-        node.class_mapping = {c.item(): g.item() for c, g in zip(unique_classes, group_assignments)}
-        node.group_indices = torch.tensor([node.class_mapping[c.item()] for c in y], dtype=torch.int)
-        node.R = R
-        node.y = y
-        node.is_leaf = False
-
-        # Create child nodes for each group
-        for group in range(num_groups):
-            mask = node.group_indices == group
-            child_node = ClassNode(current_depth + 1)
-            self._fit_node(child_node, R[mask], y[mask], current_depth + 1)
-            node.child_nodes.append(child_node)
-
-    def _fit_hierarchical(self, R_train: Tensor, y_train: Tensor):
-        """Initialize the hierarchical classification tree.
-
-        Parameters
-        ----------
-        R_train : Tensor
-            Row representations of training data of shape (train_size, D)
-
-        y_train : Tensor
-            Training targets of shape (train_size,)
-        """
-
-        self.root = ClassNode(depth=0)
-        self._fit_node(self.root, R_train, y_train, current_depth=0)
 
     def _label_encoding(self, y: Tensor) -> Tensor:
         """Remapping target values to contiguous integers starting from 0."""
@@ -196,190 +97,42 @@ class ICLearning(nn.Module):
         indices = unique_vals.argsort()
         return indices[torch.searchsorted(unique_vals, y)]
 
-    def _icl_predictions(self, R: Tensor, y_train: Tensor) -> Tensor:
-        """In-context learning predictions.
+    def _icl_predictions(self, R: Tensor, y_train_survival: tuple[Tensor, Tensor]) -> dict[str, Tensor]:
+        """In-context learning predictions for survival task."""
 
-        Parameters
-        ----------
-        R : Tensor
-            Row representations of shape (B, T, D) where:
-             - B is the number of tables
-             - T is the number of samples (rows)
-             - D is the dimension of row representations
+        y_event_train, y_time_train = y_train_survival
+        train_size = y_event_train.shape[1]
 
-        y_train : Tensor of shape (B, train_size)
-            Training targets, where train_size is the position to split
-            the input into training and test data
-        """
+        # Encode both event and time information into the training samples
+        event_embedding = self.event_encoder(y_event_train.long())
+        time_embedding = self.time_encoder(y_time_train.unsqueeze(-1))
+        R[:, :train_size] = R[:, :train_size] + event_embedding + time_embedding
 
-        train_size = y_train.shape[1]
-        R[:, :train_size] = R[:, :train_size] + self.y_encoder(y_train.float())
+        # Process through the ICL transformer
         src = self.tf_icl(R, attn_mask=train_size)
         if self.norm_first:
             src = self.ln(src)
-        out = self.decoder(src)  # (B, T, max_classes)
 
-        return out
+        # Get predictions from both heads
+        test_src = src[:, train_size:]
 
-    def _predict_standard(
-        self,
-        R: Tensor,
-        y_train: Tensor,
-        return_logits: bool = False,
-        softmax_temperature: float = 0.9,
-    ) -> Tensor:
-        """Generate predictions for standard classification with up to `max_classes` classes.
+        classification_logits = self.classification_head(test_src).squeeze(-1)
+        regression_output = self.regression_head(test_src).squeeze(-1)
 
-        Parameters
-        ----------
-        R : Tensor
-            Row representations of shape (B, T, D) where:
-             - B is the number of tables
-             - T is the number of samples (rows)
-             - D is the dimension of row representations
+        return {"logits": classification_logits, "time": regression_output}
 
-        y_train : Tensor of shape (B, train_size)
-            Training targets, where train_size is the position to split
-            the input into training and test data
 
-        return_logits : bool, default=False
-            If True, return logits instead of probabilities
-
-        softmax_temperature : float, default=0.9
-            Temperature for the softmax function
-
-        """
-
-        train_size = y_train.shape[1]
-        num_classes = len(torch.unique(y_train[0]))
-        out = self._icl_predictions(R, y_train)
-        out = out[:, train_size:, :num_classes]
-
-        if not return_logits:
-            out = torch.softmax(out / softmax_temperature, dim=-1)
-
-        return out
-
-    def _predict_hierarchical(self, R_test: Tensor, softmax_temperature: float = 0.9) -> Tensor:
-        """Generate predictions using the hierarchical classification tree.
-
-        This method traverses the tree from leaves to root, computing probabilities at each level
-        and combining them according to the probability chain rule.
-
-        Parameters
-        ----------
-        R_test : Tensor
-            Row representations of test data of shape (test_size, D)
-
-        softmax_temperature : float, default=0.9
-            Temperature for the softmax function
-
-        Returns
-        -------
-        Tensor
-            Probability over all classes, shape (test_size, C)
-        """
-
-        test_size = R_test.shape[0]
-        device = R_test.device
-        num_classes = len(self.root.classes_)
-
-        def process_node(node, R_test):
-            """Recursively process a node in the hierarchical tree.
-
-            For leaf nodes: Directly predict class probabilities within the node's subset
-            For internal nodes: Combine predictions from child nodes weighted by group probabilities
-            """
-
-            # Concatenate test data with node data
-            node_R = torch.cat([node.R.to(device), R_test], dim=0)
-
-            # Case 1: Leaf node - direct classification
-            if node.is_leaf:
-                node_y = self._label_encoding(node.y.to(device))
-                # Get predictions for this leaf
-                leaf_preds = self._predict_standard(
-                    R=node_R.unsqueeze(0),
-                    y_train=node_y.unsqueeze(0),
-                    softmax_temperature=softmax_temperature,
-                ).squeeze(0)
-                # Map leaf predictions to the global class space
-                global_preds = torch.zeros((test_size, num_classes), device=device)
-                for local_idx, global_idx in enumerate(node.classes_):
-                    global_preds[:, global_idx] = leaf_preds[:, local_idx]
-
-                return global_preds
-
-            # Case 2: Internal node - classification into groups
-            # Initialize output tensor for all classes
-            final_probs = torch.zeros((test_size, num_classes), device=device)
-
-            # Get group probabilities for this node
-            node_y = node.group_indices.to(device)
-            group_probs = self._predict_standard(
-                R=node_R.unsqueeze(0),
-                y_train=node_y.unsqueeze(0),
-                softmax_temperature=softmax_temperature,
-            ).squeeze(0)
-
-            # Recursively process child nodes and combine predictions
-            for group_idx, child_node in enumerate(node.child_nodes):
-                child_probs = process_node(child_node, R_test)
-                final_probs += child_probs * group_probs[:, group_idx : group_idx + 1]
-
-            return final_probs
-
-        return process_node(self.root, R_test)
 
 
     def forward(
         self,
         R: Tensor,
-        y_train: Tensor,
-        return_logits: bool = True,
-        softmax_temperature: float = 0.9,
-    ) -> Tensor:
-        """In-context learning based on learned row representations.
-
-        Parameters
-        ----------
-        R : Tensor
-            Row representations of shape (B, T, D) where:
-             - B is the number of tables
-             - T is the number of samples (rows)
-             - D is the dimension of row representations
-
-        y_train : Tensor of shape (B, train_size)
-            Training targets, where train_size is the position to split
-            the input into training and test data
-
-        return_logits : bool, default=True
-            If True, return logits instead of probabilities. Used only in inference mode.
-
-        softmax_temperature : float, default=0.9
-            Temperature for the softmax function. Used only in inference mode.
-
-
-        Returns
-        -------
-        Tensor
-            For training mode:
-              Raw logits of shape (B, T-train_size, max_classes), which will be further handled by the training code.
-
-            For inference mode:
-              Raw logits or probabilities for test samples of shape (B, T-train_size, num_classes).
+        y_train: tuple[Tensor, Tensor],
+    ) -> dict[str, Tensor]:
+        """
+        Simplified forward pass for survival pre-training.
         """
 
-        if self.training:
-            train_size = y_train.shape[1]
-            out = self._icl_predictions(R, y_train)
-            out = out[:, train_size:]
-        else:
-            out = self._predict_standard(
-                R,
-                y_train,
-                return_logits=return_logits,
-                softmax_temperature=softmax_temperature,
-            )
-
-        return out
+        # This is only used during training, so we call _icl_predictions directly.
+        # The complex inference logic is not needed for pre-training.
+        return self._icl_predictions(R, y_train)


### PR DESCRIPTION
## Summary
- update `ICLearning` for survival analysis with event/time heads
- simplify TabICL forward pass for survival training
- adapt training loop in `run.py` for event-time batches and combined loss
- add script to launch survival pretraining

## Testing
- `pytest -q`
- `python -m py_compile src/tabicl/model/learning.py src/tabicl/model/tabicl.py src/tabicl/train/run.py`

------
https://chatgpt.com/codex/tasks/task_e_6846578ccd50832b8ceaaf7269760021